### PR TITLE
Handle root URL's with trailing slash

### DIFF
--- a/samlsp/samlsp.go
+++ b/samlsp/samlsp.go
@@ -37,10 +37,10 @@ type Options struct {
 
 // New creates a new Middleware
 func New(opts Options) (*Middleware, error) {
-	metadataURL := opts.URL
-	metadataURL.Path = metadataURL.Path + "/saml/metadata"
-	acsURL := opts.URL
-	acsURL.Path = acsURL.Path + "/saml/acs"
+	metadataRelURL, _ := url.Parse("saml/metadata")
+	metadataURL := opts.URL.ResolveReference(metadataRelURL)
+	acsRelURL, _ := url.Parse("saml/acs")
+	acsURL := opts.URL.ResolveReference(acsRelURL)
 	logr := opts.Logger
 	if logr == nil {
 		logr = logger.DefaultLogger
@@ -56,8 +56,8 @@ func New(opts Options) (*Middleware, error) {
 			Key:         opts.Key,
 			Logger:      logr,
 			Certificate: opts.Certificate,
-			MetadataURL: metadataURL,
-			AcsURL:      acsURL,
+			MetadataURL: *metadataURL,
+			AcsURL:      *acsURL,
 			IDPMetadata: opts.IDPMetadata,
 			ForceAuthn:  &opts.ForceAuthn,
 		},


### PR DESCRIPTION
Fixes an issue where requests to retrieve the metadata, such as `localhost:8000/saml/metadata`,
would fail with a 404 when `URL` option had a trailing slash, such as 

```
rootURL, err := url.Parse("http://localhost:8000/")
.
.
.
samlsp.Options{
	URL: *rootUrl,
```

Rather than textually appending the middlware paths to the given root URL's path, this uses
[ResolveReference](https://golang.org/pkg/net/url/#URL.ResolveReference) to reliably create
a URL relative to the root URL given by the user.

Previously, when textually appended, the `metadataURL` would end up with a double slash, such as
`http://localhost:8000//saml/metadata` and therefore the path matching in the [middleware's
ServeHTTP](https://github.com/crewjam/saml/blob/ebc5f787b786ee76ee69bf49184fade38d2238af/samlsp/middleware.go#L68)
would never match since the incoming `r.URL.Path` would be just `/saml/metadata`.